### PR TITLE
Use LINQ to XML to replace handcrafted SSML

### DIFF
--- a/Samples-Http/CSharp/TTSProgram.cs
+++ b/Samples-Http/CSharp/TTSProgram.cs
@@ -215,8 +215,8 @@ namespace TTSSample
                                   new XElement("voice",
                                       new XAttribute(XNamespace.Xml + "lang", locale),
                                       new XAttribute(XNamespace.Xml + "gender", gender),
-                                      new XAttribute("name", name)),
-                                  text));
+                                      new XAttribute("name", name),
+                                      text)));
             return ssmlDoc.ToString();
         }
 


### PR DESCRIPTION
The change is to make SSML generation more structured and less trouble handling escapes, etc.