### PR TITLE
Fix android sample issue (lang attribute should be in voice element)

### DIFF
--- a/Android/Sample/app/src/main/java/com/microsoft/sdksample/MainActivity.java
+++ b/Android/Sample/app/src/main/java/com/microsoft/sdksample/MainActivity.java
@@ -36,11 +36,10 @@ package com.microsoft.sdksample;
 import android.app.AlertDialog;
 import android.support.v7.app.ActionBarActivity;
 import android.os.Bundle;
-import android.view.Menu;
-import android.view.MenuItem;
 import android.widget.Toast;
 
-import com.microsoft.speech.tts.*;
+import com.microsoft.speech.tts.Synthesizer;
+import com.microsoft.speech.tts.Voice;
 
 public class MainActivity extends ActionBarActivity {
     // Note: Sign up at http://www.projectoxford.ai for the client credentials.
@@ -76,7 +75,7 @@ public class MainActivity extends ActionBarActivity {
             m_syn.SpeakToAudio(getString(R.string.tts_text));
 
             // Use SSML for speech.
-            String text = "<speak version=\"1.0\" xmlns=\"http://www.w3.org/2001/10/synthesis\" xmlns:mstts=\"http://www.w3.org/2001/mstts\" xml:lang=\"en-US\"><voice name=\"Microsoft Server Speech Text to Speech Voice (en-US, ZiraRUS)\">You can also use SSML markup for text to speech.</voice></speak>";
+            String text = "<speak version=\"1.0\" xmlns=\"http://www.w3.org/2001/10/synthesis\" xmlns:mstts=\"http://www.w3.org/2001/mstts\" xml:lang=\"en-US\"><voice xml:lang=\"en-US\" name=\"Microsoft Server Speech Text to Speech Voice (en-US, ZiraRUS)\">You can also use SSML markup for text to speech.</voice></speak>";
             m_syn.SpeakSSMLToAudio(text);
         }
     }


### PR DESCRIPTION
Android sample never speak any text, so I found Bing Text To Speech API was changed in this document, [Example Voice Output Request](https://www.microsoft.com/cognitive-services/en-us/Speech-api/documentation/API-Reference-REST/BingVoiceOutput)