### PR TITLE
Add speechsdk dependency configration for debug and release

### DIFF
--- a/Android/Sample/app/build.gradle
+++ b/Android/Sample/app/build.gradle
@@ -26,6 +26,8 @@ repositories {
 }
 
 dependencies {
-    compile(name: 'speechsdk', ext: 'aar')
+    releaseCompile(name: 'speechsdk', ext: 'aar')
+    debugCompile project(path: ':speechsdk')
+
     compile 'com.android.support:appcompat-v7:22.1.0'
 }


### PR DESCRIPTION
When build variant is debug for testing or debugging, speechsdk library dependency is speechsdk module(folder).
When variant is release, speechsdk library dependency is speechsdk.arr in libs of app module.