### PR TITLE
support new unified key and api endpoint

### DIFF
--- a/Samples-Http/CSharp/TTSClient.cs
+++ b/Samples-Http/CSharp/TTSClient.cs
@@ -48,7 +48,7 @@ namespace CognitiveServicesTTS
     /// </summary>
     public class Authentication
     {
-        public static readonly string AccessUri = "https://api.cognitive.microsoft.com/sts/v1.0/issueToken";
+        private string AccessUri;
         private string apiKey;
         private string accessToken;
         private Timer accessTokenRenewer;
@@ -56,11 +56,12 @@ namespace CognitiveServicesTTS
         //Access token expires every 10 minutes. Renew it every 9 minutes only.
         private const int RefreshTokenDuration = 9;
 
-        public Authentication(string apiKey)
+        public Authentication(string issueTokenUri, string apiKey)
         {
+            this.AccessUri = issueTokenUri;
             this.apiKey = apiKey;
 
-            this.accessToken = HttpPost(AccessUri, this.apiKey);
+            this.accessToken = HttpPost(issueTokenUri, this.apiKey);
 
             // renew the token every specfied minutes
             accessTokenRenewer = new Timer(new TimerCallback(OnTokenExpiredCallback),

--- a/Samples-Http/CSharp/TTSProgram.cs
+++ b/Samples-Http/CSharp/TTSProgram.cs
@@ -74,10 +74,18 @@ namespace TTSSample
             Console.WriteLine("Starting Authtentication");
             string accessToken;
 
-            // Note: The way to get api key:
+            // Issue token uri for old Bing Speech API "https://api.cognitive.microsoft.com/sts/v1.0/issueToken";
+            // Issue token uri for new unified SpeechService API "https://westus.api.cognitive.microsoft.com/sts/v1.0/issueToken". 
+            // Note: new unified SpeechService API key and issue token uri is per region
+
+            // The way to get api key:
+            // Old Bing Speech key
             // Free: https://www.microsoft.com/cognitive-services/en-us/subscriptions?productId=/products/Bing.Speech.Preview
             // Paid: https://portal.azure.com/#create/Microsoft.CognitiveServices/apitype/Bing.Speech/pricingtier/S0
-            Authentication auth = new Authentication("Your api key goes here");
+            // New unified SpeechService key
+            // Free: https://azure.microsoft.com/en-us/try/cognitive-services/?api=speech-services
+            // Paid: https://go.microsoft.com/fwlink/?LinkId=872236&clcid=0x409 
+            Authentication auth = new Authentication("https://westus.api.cognitive.microsoft.com/sts/v1.0/issueToken", "input your key here");
             
             try
             {
@@ -93,7 +101,10 @@ namespace TTSSample
             }
 
             Console.WriteLine("Starting TTSSample request code execution.");
-            string requestUri = "https://speech.platform.bing.com/synthesize";
+            // Synthesis endpoint for old Bing Speech API: https://speech.platform.bing.com/synthesize
+            // For new unified SpeechService API: https://westus.tts.speech.microsoft.com/cognitiveservices/v1
+            // Note: new unified SpeechService API synthesis endpoint is per region
+            string requestUri = "https://westus.tts.speech.microsoft.com/cognitiveservices/v1";
             var cortana = new Synthesize();
 
             cortana.OnAudioAvailable += PlayAudio;


### PR DESCRIPTION
Add new unified key and API endpoint for standard cognitive TTS
Moving forward standard cognitive TTS support 2 types of keys and APIs:
1. Existing cognitive TTS user can continue use old key and endpoint, plus the new ones.
2. New user can only use new unified key and endpoint