### PR TITLE
specify UTF-8 charset when getting bytes from string

### DIFF
--- a/Android/Sample/speechsdk/src/main/java/com/microsoft/speech/tts/Authentication.java
+++ b/Android/Sample/speechsdk/src/main/java/com/microsoft/speech/tts/Authentication.java
@@ -119,7 +119,7 @@ class Authentication {
             webRequest.setRequestMethod("POST");
 
             String request = "";
-            byte[] bytes = request.getBytes();
+            byte[] bytes = request.getBytes("UTF-8");
             webRequest.setRequestProperty("content-length", String.valueOf(bytes.length));
             webRequest.connect();
 

--- a/Android/Sample/speechsdk/src/main/java/com/microsoft/speech/tts/TtsServiceClient.java
+++ b/Android/Sample/speechsdk/src/main/java/com/microsoft/speech/tts/TtsServiceClient.java
@@ -77,7 +77,7 @@ class TtsServiceClient {
                 urlConnection.setRequestProperty("X-Search-ClientID", "1ECFAE91408841A480F00935DC390960");
                 urlConnection.setRequestProperty("User-Agent", "TTSAndroid");
                 urlConnection.setRequestProperty("Accept", "*/*");
-                byte[] ssmlBytes = ssml.getBytes();
+                byte[] ssmlBytes = ssml.getBytes("UTF-8");
                 urlConnection.setRequestProperty("content-length", String.valueOf(ssmlBytes.length));
                 urlConnection.connect();
                 urlConnection.getOutputStream().write(ssmlBytes);

--- a/Samples-Http/Java/TTSSample/src/com/microsoft/cognitiveservices/ttssample/TTSService.java
+++ b/Samples-Http/Java/TTSSample/src/com/microsoft/cognitiveservices/ttssample/TTSService.java
@@ -71,7 +71,7 @@ public class TTSService {
         webRequest.setRequestProperty("Accept", "*/*");
 
         String body = XmlDom.createDom(locale, genderName, voiceName, textToSynthesize);
-        byte[] bytes = body.getBytes();
+        byte[] bytes = body.getBytes("UTF-8");
         webRequest.setRequestProperty("content-length", String.valueOf(bytes.length));
         webRequest.connect();
 


### PR DESCRIPTION
Better to specify UTF-8 when geting bytes from string, since not all platforms' default charset is UTF-8.